### PR TITLE
Atomic updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Keeps `z` index of the widgets unique, moves the widgets around in the case of c
 
 Repository implemented with an in memory solution and with a H2 embedded database. 
 Implementation to be wired depends on the  `application.repository.type` in `application.yml`
-- `h2` is the value for database implementation 
+- `db` is the value for database implementation 
 - `memory` is the value for in memory implementation 
 
 ### Features

--- a/src/main/java/com/yergun/widgetservice/repository/CustomizedWidgetRepository.java
+++ b/src/main/java/com/yergun/widgetservice/repository/CustomizedWidgetRepository.java
@@ -1,0 +1,11 @@
+package com.yergun.widgetservice.repository;
+
+import com.yergun.widgetservice.model.Widget;
+import com.yergun.widgetservice.model.WidgetPatchRequest;
+
+import java.util.UUID;
+
+public interface CustomizedWidgetRepository {
+    Widget update(UUID id, WidgetPatchRequest patchRequest);
+    Widget save(Widget widget);
+}

--- a/src/main/java/com/yergun/widgetservice/repository/CustomizedWidgetRepositoryImpl.java
+++ b/src/main/java/com/yergun/widgetservice/repository/CustomizedWidgetRepositoryImpl.java
@@ -1,0 +1,66 @@
+package com.yergun.widgetservice.repository;
+
+import com.yergun.widgetservice.exception.WidgetNotFoundException;
+import com.yergun.widgetservice.model.Widget;
+import com.yergun.widgetservice.model.WidgetPatchRequest;
+import com.yergun.widgetservice.util.ObjectUtils;
+import org.springframework.beans.BeanUtils;
+import org.springframework.stereotype.Component;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class CustomizedWidgetRepositoryImpl implements CustomizedWidgetRepository {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Override
+    public Widget update(UUID id, WidgetPatchRequest patchRequest) {
+
+        Widget widget = entityManager.find(Widget.class, id);
+        if(widget == null) {
+            throw new WidgetNotFoundException(id);
+        }
+
+        this.moveIfZIndexCollision(patchRequest.getZ());
+        BeanUtils.copyProperties(patchRequest, widget, ObjectUtils.getNullPropertyNames(patchRequest));
+        widget.setLastUpdated(LocalDateTime.now());
+        entityManager.persist(widget);
+        return widget;
+    }
+
+    @Override
+    public Widget save(Widget widget) {
+        this.moveIfZIndexCollision(widget.getZ());
+        entityManager.persist(widget);
+        return widget;
+    }
+
+    private void moveIfZIndexCollision(Integer z) {
+        entityManager
+                .createQuery("Select w FROM Widget w WHERE w.z = :z", Widget.class)
+                .setParameter("z", z)
+                .getResultStream()
+                .findFirst()
+                .ifPresent( w -> incrementGreaterZs(w.getZ()));
+    }
+
+    private void incrementGreaterZs(Integer z) {
+        List<Widget> widgets = entityManager
+                .createQuery("Select w FROM Widget w WHERE w.z >= :z", Widget.class)
+                .setParameter("z", z).getResultList();
+
+        widgets.forEach(w -> {
+                    w.incrementZ();
+                    w.setLastUpdated(LocalDateTime.now());
+                    entityManager.persist(w);
+                });
+    }
+}

--- a/src/main/java/com/yergun/widgetservice/repository/WidgetRepository.java
+++ b/src/main/java/com/yergun/widgetservice/repository/WidgetRepository.java
@@ -1,6 +1,7 @@
 package com.yergun.widgetservice.repository;
 
 import com.yergun.widgetservice.model.Widget;
+import com.yergun.widgetservice.model.WidgetPatchRequest;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,15 +12,14 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
 
-@ConditionalOnProperty(name = "application.repository.type", havingValue = "h2")
-public interface WidgetRepository extends Repository<Widget, UUID> {
+@ConditionalOnProperty(name = "application.repository.type", havingValue = "db")
+public interface WidgetRepository extends Repository<Widget, UUID>, CustomizedWidgetRepository {
 
     // I really wanted the method signature like this
     // so I can utilize `tailSet` method in inMemory implementation as it's amortised O(1)
     @Query("select w from Widget w where w.z >= :#{#widget.z} order by w.z asc")
     Collection<Widget> findByZGreaterThanEqualOrderByZAsc(Widget widget);
     Page<Widget> findByOrderByZAsc(Pageable pageable);
-    Widget save(Widget widget);
     Optional<Widget> findFirstByOrderByZDesc();
     Optional<Widget> findFirstByZ(Integer z);
     Optional<Widget> findById(UUID id);

--- a/src/main/java/com/yergun/widgetservice/repository/WidgetRepositoryInMemory.java
+++ b/src/main/java/com/yergun/widgetservice/repository/WidgetRepositoryInMemory.java
@@ -1,15 +1,21 @@
 package com.yergun.widgetservice.repository;
 
+import com.yergun.widgetservice.exception.WidgetNotFoundException;
 import com.yergun.widgetservice.model.Widget;
+import com.yergun.widgetservice.model.WidgetPatchRequest;
+import com.yergun.widgetservice.util.ObjectUtils;
 import lombok.Getter;
+import org.springframework.beans.BeanUtils;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
 @ConditionalOnProperty(name = "application.repository.type", havingValue = "memory")
@@ -17,57 +23,139 @@ import java.util.stream.Collectors;
 @Getter
 public class WidgetRepositoryInMemory implements WidgetRepository {
 
-    private final SortedSet<Widget> storage = new ConcurrentSkipListSet<>(Comparator.comparingInt(Widget::getZ));
+    private final SortedSet<Widget> storage = new TreeSet<>(Comparator.comparingInt(Widget::getZ));
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock(true);
 
     @Override
     public Widget save(Widget widget) {
-        storage.add(widget);
-        return widget;
+        lock.writeLock().lock();
+        try {
+            moveIfZIndexCollision(widget);
+            storage.add(widget);
+            return widget;
+        } finally {
+            lock.writeLock().unlock();
+        }
     }
 
     @Override
     public Optional<Widget> findFirstByOrderByZDesc() {
-        return storage.isEmpty() ? Optional.empty() : Optional.of(storage.last());
+        lock.readLock().lock();
+        try {
+            return storage.isEmpty() ? Optional.empty() : Optional.of(storage.last());
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     @Override
     public Page<Widget> findByOrderByZAsc(Pageable pageable) {
-        List<Widget> list = storage.stream()
-                .skip(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .collect(Collectors.toList());
+        lock.readLock().lock();
+        try {
+            List<Widget> list = storage.stream()
+                    .skip(pageable.getOffset())
+                    .limit(pageable.getPageSize())
+                    .collect(Collectors.toList());
+            return new PageImpl<>(list, pageable, storage.size());
+        } finally {
+            lock.readLock().unlock();
+        }
 
-        return new PageImpl<>(list, pageable, storage.size());
     }
 
     @Override
     public Collection<Widget> findByZGreaterThanEqualOrderByZAsc(Widget widget) {
-        return storage.tailSet(widget);
+        lock.readLock().lock();
+        try {
+            return storage.tailSet(widget);
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     public Optional<Widget> findFirstByZ(Integer zIndex) {
-        return storage.stream()
-                .filter(w -> w.getZ().equals(zIndex))
-                .findFirst();
+        lock.readLock().lock();
+        try {
+            return storage.stream()
+                    .filter(w -> w.getZ().equals(zIndex))
+                    .findFirst();
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     @Override
     public Optional<Widget> findById(UUID id) {
-        return storage.stream()
-                .filter(w -> w.getId().equals(id))
-                .findFirst();
+        lock.readLock().lock();
+        try {
+            return storage.stream()
+                    .filter(w -> w.getId().equals(id))
+                    .findFirst();
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     @Override
     public boolean deleteById(UUID id) {
-        return storage.removeIf(w -> w.getId().equals(id));
+        lock.writeLock().lock();
+        try {
+            return storage.removeIf(w -> w.getId().equals(id));
+        } finally {
+            lock.writeLock().unlock();
+        }
     }
 
     @Override
     public void delete(Widget widget) {
-        storage.remove(widget);
+        lock.writeLock().lock();
+        try {
+            storage.remove(widget);
+        } finally {
+            lock.writeLock().unlock();
+        }
     }
 
+    @Override
+    public Widget update(UUID id, WidgetPatchRequest patchRequest) {
+        lock.writeLock().lock();
+        try {
+            Widget widget = storage.stream()
+                    .filter(w -> w.getId().equals(id))
+                    .findFirst()
+                    .orElseThrow(() -> new WidgetNotFoundException(id));
+            storage.remove(widget);
+            BeanUtils.copyProperties(patchRequest, widget, ObjectUtils.getNullPropertyNames(patchRequest));
+            widget.setLastUpdated(LocalDateTime.now());
+            moveIfZIndexCollision(widget);
+            storage.add(widget);
+            return widget;
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
 
+    /**
+     * used only under writeLock
+     * @param widget
+     */
+    private void moveIfZIndexCollision(Widget widget) {
+        storage.stream()
+                .filter(w -> w.getZ().equals(widget.getZ()))
+                .findFirst()
+                .ifPresent(this::moveWidgetsGreaterThanToForegroundByOne);
+    }
 
+    /**
+     * used only under writeLock
+     * @param widget
+     */
+    private void moveWidgetsGreaterThanToForegroundByOne(Widget widget) {
+        this.findByZGreaterThanEqualOrderByZAsc(widget)
+                .forEach(w -> {
+                    w.incrementZ();
+                    w.setLastUpdated(LocalDateTime.now());
+                    storage.add(w);
+                });
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,4 +5,4 @@ spring:
 application:
   repository:
     type: memory
-    #type: h2
+#    type: db

--- a/src/test/java/com/yergun/widgetservice/TestUtils.java
+++ b/src/test/java/com/yergun/widgetservice/TestUtils.java
@@ -48,7 +48,7 @@ public interface TestUtils {
     static void fillWidgets(int count, WidgetRepository repository) {
         for (int i = 0; i < count; i++) {
             repository.save(new Widget(UUID.randomUUID(),
-                    10, 10, i,
+                    10, 10, 10,
                     10, i, LocalDateTime.now()));
         }
     }

--- a/src/test/java/com/yergun/widgetservice/service/WidgetServiceTest.java
+++ b/src/test/java/com/yergun/widgetservice/service/WidgetServiceTest.java
@@ -143,36 +143,4 @@ class WidgetServiceTest {
         assertThatExceptionOfType(WidgetNotFoundException.class)
                 .isThrownBy(() -> widgetService.deleteById(UUID.randomUUID()));
     }
-
-    @Test
-    void update_whenNotFound_ThrowsWidgetNotFoundException() {
-        when(widgetRepository.findById(any())).thenReturn(Optional.empty());
-
-        assertThatExceptionOfType(WidgetNotFoundException.class)
-                .isThrownBy(() -> widgetService.update(UUID.randomUUID(), new WidgetPatchRequest()));
-    }
-
-    @Test
-    void update_whenCalledWithHeight_updatesOnlyHeight() {
-        UUID id = UUID.randomUUID();
-        Widget widget = Widget.builder().id(id)
-                .x(10).y(10).width(10).height(10).z(0).build();
-
-        WidgetPatchRequest wpr = new WidgetPatchRequest();
-        wpr.setHeight(666);
-
-        when(widgetRepository.findById(id)).thenReturn(Optional.of(widget));
-        when(widgetRepository.save(any())).thenAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
-
-        Widget updated = widgetService.update(id, wpr);
-
-        assertThat(updated.getHeight()).isEqualTo(wpr.getHeight());
-        assertThat(updated.getWidth()).isEqualTo(10);
-        assertThat(updated.getX()).isEqualTo(10);
-        assertThat(updated.getY()).isEqualTo(10);
-        assertThat(updated.getZ()).isEqualTo(0);
-    }
-
-
-
 }


### PR DESCRIPTION
- Handling z indexes moved to repository level
- Atomic updates achieved by:
  - _in memory implementation_: `ReentrantReadWriteLock` for locking mechanism to achieve exclusive write locks, multiple reads are allowed if there is no write operation going on.
  - _database implementation_: `@Transactional` on save/update methods